### PR TITLE
secure DOIs

### DIFF
--- a/app.py
+++ b/app.py
@@ -29,7 +29,7 @@ def get_link(art):
     article_id_list.sort(key=len)
 
     if '/' in article_id_list[-1]:
-        art['link'] = 'http://dx.doi.org/'+article_id_list[-1]
+        art['link'] = 'https://doi.org/'+article_id_list[-1]
     else:
         art['link'] = None
     return art


### PR DESCRIPTION
`dx.doi.org` is no longer the preferred resolver, see https://www.doi.org/doi_handbook/3_Resolution.html#3.8
